### PR TITLE
Proposal: Unique ID for each Variable

### DIFF
--- a/ast.cpp
+++ b/ast.cpp
@@ -60,7 +60,7 @@ namespace ast {
 	bool variable::operator==(const node& other) const {
 		if(typeid(other) != typeid(variable)) return false;
 		auto o = dynamic_cast<const variable&>(other);
-		return *o.var_type == *var_type && o.name == name;
+		return id == o.id;
 	}
 	std::ostream& variable::print_to(std::ostream& stream) const {
 		return stream << name;

--- a/ast.h
+++ b/ast.h
@@ -67,7 +67,8 @@ namespace ast {
 	struct variable : public expression {
 		sptr<type> var_type;
 		string name;
-		variable(sptr<type> var_type, string name) : var_type(var_type), name(name) {}
+		int id;
+		variable(sptr<type> var_type, string name, int id) : var_type(var_type), name(name), id(id) {}
 		virtual bool operator==(const node& other) const;
 		virtual std::ostream& print_to(std::ostream& stream) const;
 	};

--- a/parser.cpp
+++ b/parser.cpp
@@ -303,11 +303,12 @@ namespace parser {
 	}
 
 	sptr<ast::decl_stmt> decl_stmt(parser_state& p) {
+		static int id = 0;
 		auto var_type = type(p);
 		if(!var_type) return {};
-		auto id = consume_identifier(p);
-		if(id.empty()) throw parser_error(p, "Expected identifier in variable declaration");
-		auto var = std::make_shared<ast::variable>(var_type, id);
+		auto ident = consume_identifier(p);
+		if(ident.empty()) throw parser_error(p, "Expected identifier in variable declaration");
+		auto var = std::make_shared<ast::variable>(var_type, ident, id++);
 		auto init_eq = try_token(p, "=");
 		sptr<ast::expression> init_expr;
 		if(!init_eq.empty()) {
@@ -315,7 +316,7 @@ namespace parser {
 		}
 		if(try_token(p, ";").empty()) throw parser_error(p, "Expected ';' at end of statement");
 		// store variable in current scope
-		p.scopes.back().declare(p, id, var);
+		p.scopes.back().declare(p, ident, var);
 		return std::make_shared<ast::decl_stmt>(var, init_expr);
 	}
 

--- a/tests/parser_tests.cpp
+++ b/tests/parser_tests.cpp
@@ -40,7 +40,7 @@ void test_parser() {
 	EXPECT_NO_MATCH(parser::variable, str_4dot5);
 	{
 		parser::parser_state p(str_test.cbegin(), str_test.cend());
-		sptr<ast::variable> var = std::make_shared<ast::variable>(std::make_shared<ast::int_type>(), str_test);
+		sptr<ast::variable> var = std::make_shared<ast::variable>(std::make_shared<ast::int_type>(), str_test, 0);
 		p.scopes.back().declare(p, str_test, var);
 		// freestanding
 		auto match = parser::variable(p);


### PR DESCRIPTION
This patch adds an `int` to each variable which uniquely identifies it. It can be used to distinguish two variables with the same name declared in different scopes, without a scope table.
